### PR TITLE
Consumable health and stamina potions that restore stats

### DIFF
--- a/server/entity/Item.gd
+++ b/server/entity/Item.gd
@@ -1,13 +1,15 @@
 extends "res://server/entity/entity.gd"
 
-var id
+var id = null
+var MAX_CAPACITY = 4
 
 onready var world = get_tree().get_root().get_node("World")
 
 func _ready():
 	#id=0 health potion
 	#id=1 stamina potion
-	id = randi()%2
+	#id = randi()%2
+	#print("Randi result = ", id)
 	
 	who = "item"
 	get_node("hitbox").set_shape(load("res://server/entity/entity_resources/mob_hitbox.tres"))
@@ -25,8 +27,19 @@ func move():
 	rpc("remote_move", position)
 	
 func picked_up(i):
-	i.inventory[id] += 1
-	world.update_inventory_to_client(i)
-	rpc_id(int(i.get_name()), "picked_up")
+	# prevent from picking up too many of an item
+	if i.inventory[id] != MAX_CAPACITY:
+		i.inventory[id] += 1
+		print("S-Health = ", i.inventory[0])
+		print("S-Stmina = ", i.inventory[1])
+		print("")
+		world.update_inventory_to_client(i)
+		rpc_id(int(i.get_name()), "picked_up")
+		
+	else:
+		print("Not enough room for this item!")
+	
+	# item deletes regardless of player pickup to prevent item collision issue
+	# with a full inventory
 	rpc("delete_me")
 	queue_free()

--- a/server/entity/Item.gd
+++ b/server/entity/Item.gd
@@ -1,10 +1,14 @@
 extends "res://server/entity/entity.gd"
 
-var id = 0
+var id
 
 onready var world = get_tree().get_root().get_node("World")
 
 func _ready():
+	#id=0 health potion
+	#id=1 stamina potion
+	id = randi()%2
+	
 	who = "item"
 	get_node("hitbox").set_shape(load("res://server/entity/entity_resources/mob_hitbox.tres"))
 	set_collision_layer_bit(Base.ITEM_COLLISION_LAYER, true) # 

--- a/server/entity/Item.gd
+++ b/server/entity/Item.gd
@@ -30,12 +30,8 @@ func picked_up(i):
 	# prevent from picking up too many of an item
 	if i.inventory[id] != MAX_CAPACITY:
 		i.inventory[id] += 1
-		print("S-Health = ", i.inventory[0])
-		print("S-Stmina = ", i.inventory[1])
-		print("")
 		world.update_inventory_to_client(i)
 		rpc_id(int(i.get_name()), "picked_up")
-		
 	else:
 		print("Not enough room for this item!")
 	

--- a/server/entity/Mob.gd
+++ b/server/entity/Mob.gd
@@ -65,8 +65,9 @@ remote func take_damage(x):
 	health -= x
 	rpc("set_health", health)
 	if (health <= 0):
+		# 50/50 chance to spawn item
 		var chance = randi()%4
 		if chance == 0 || chance == 1:
-			world.get_node("Spawning/ItemSpawner").spawn_item(position, chance) # spawn a potion
+			world.get_node("Spawning/ItemSpawner").spawn_item(position) # spawn a potion
 		rpc("delete_me")
 		queue_free()

--- a/server/entity/Mob.gd
+++ b/server/entity/Mob.gd
@@ -46,6 +46,8 @@ remote func take_damage(x):
 	health -= x
 	rpc("set_health", health)
 	if (health <= 0):
-		world.get_node("Spawning/ItemSpawner").spawn_item(position, 0) # spawn a potion
+		var chance = randi()%4
+		if chance == 0 || chance == 1:
+			world.get_node("Spawning/ItemSpawner").spawn_item(position, chance) # spawn a potion
 		rpc("delete_me")
 		queue_free()

--- a/server/entity/Player.gd
+++ b/server/entity/Player.gd
@@ -92,7 +92,15 @@ func check_position():
 			position = w.get_node("entities/players").get_child(index).get_global_position()
 		velocity.y = 0
 		
+		health = MAX_HEALTH/2
+		mana = MAX_MANA/2
+		stamina = MAX_STAMINA/2
 		
+		rpc("set_health", health)
+		rpc("set_mana", mana)
+		rpc("set_stamina", stamina)
+
+
 func give_client_stats():
 	rpc_id(int(get_name()), "update_stats", health, mana, stamina, defense, speed, damage)
 	
@@ -109,3 +117,18 @@ func take_damage(x):
 		mana = MAX_MANA/2
 		stamina = MAX_STAMINA/2
 		
+		rpc("set_health", health)
+		rpc("set_mana", mana)
+		rpc("set_stamina", stamina)
+
+
+remote func restore_stats(id):
+	if id == 0:
+		health += 60
+		if (health > MAX_HEALTH):
+			health = MAX_HEALTH
+		
+		rpc("set_health", health)
+	elif id == 1:
+		stamina = MAX_STAMINA
+		rpc("set_stamina", stamina)

--- a/server/entity/entity.gd
+++ b/server/entity/entity.gd
@@ -57,3 +57,7 @@ func check_position():
 		position = get_tree().get_root().get_node("World/Spawning/PlayerSpawnPoints").get_child(0).get_global_position()
 		#position = Vector2(0,0)
 		velocity.y = 0
+		
+		health = MAX_HEALTH
+		mana = MAX_MANA
+		stamina = MAX_STAMINA

--- a/server/lobby.tscn
+++ b/server/lobby.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource path="res://server/lobby.gd" type="Script" id=1]
 
-[node name="global_player" type="Node" index="0"]
+[node name="global_player" type="Node"]
 
 script = ExtResource( 1 )
 

--- a/server/spawning/ItemSpawner.gd
+++ b/server/spawning/ItemSpawner.gd
@@ -13,8 +13,6 @@ func spawn_item(pos):
 	new_item.position = pos
 	new_item.id = randi()%2
 	
-	print("Newly created item with id = ", new_item.id)
-	
 	get_tree().get_root().get_node("World").item_drop(unique_id, new_item.id)
 	items.add_child(new_item)
 

--- a/server/spawning/ItemSpawner.gd
+++ b/server/spawning/ItemSpawner.gd
@@ -6,14 +6,16 @@ var items = null
 func _ready():
 	pass
 
-func spawn_item(pos, id):
+func spawn_item(pos):
 	var unique_id = randi()%10000000000 + 1 # <== Better hope we don't generate two of the same id	
 	var new_item = item.new()
 	new_item.set_name(str(unique_id))
 	new_item.position = pos
-	new_item.id = id
+	new_item.id = randi()%2
 	
-	get_tree().get_root().get_node("World").item_drop(unique_id, id)
+	print("Newly created item with id = ", new_item.id)
+	
+	get_tree().get_root().get_node("World").item_drop(unique_id, new_item.id)
 	items.add_child(new_item)
 
 

--- a/server/spawning/PlayerSpawner.gd
+++ b/server/spawning/PlayerSpawner.gd
@@ -55,9 +55,14 @@ func spawn_initial(params):
 		global_player.player_info[p]["data"] = info[1]
 		new_player.inventory = info[1]["items"]
 		
+		print("S-Init-Health = ", new_player.inventory[0])
+		print("S-Init-Stmina = ", new_player.inventory[1])
+		print("")
+		
 		players.add_child(new_player)
 		respawn = true
 	global_player.finished_loading()
+	
 	return true
 
 

--- a/server/spawning/PlayerSpawner.gd
+++ b/server/spawning/PlayerSpawner.gd
@@ -55,10 +55,6 @@ func spawn_initial(params):
 		global_player.player_info[p]["data"] = info[1]
 		new_player.inventory = info[1]["items"]
 		
-		print("S-Init-Health = ", new_player.inventory[0])
-		print("S-Init-Stmina = ", new_player.inventory[1])
-		print("")
-		
 		players.add_child(new_player)
 		respawn = true
 	global_player.finished_loading()


### PR DESCRIPTION
- Health and stamina potions are functional, four of each can be held at a time.

- Health potions restore 60 hp, stamina potions restore complete stamina

- HUD element tracks amount of potions in inventory

- Added missing functions for updating the clientside stats on respawns

- Respawns from jumping off map reset stats appropriately