### PR TITLE
Optimizing Player's implementation of Mob detection

### DIFF
--- a/server/entity/Mob.gd
+++ b/server/entity/Mob.gd
@@ -26,13 +26,19 @@ func _on_area_body_entered(body):
 	if body.is_class("TileMap"):
 		velocity.y = -1.5*150
 	elif body.who == "player":
-		nearby_players[body] = true
+		enemies_in_range[body] = true
+	
 		
 func _on_area_body_exited(body):
 	if body.is_class("TileMap"):
 		return
 	if body.who == "player":
-		nearby_players[body] = false
+		enemies_in_range.erase(body)
+	
+	
+func _physics_process(delta):
+	move()
+	
 	
 func find_nearest_player():
 	var minx = 300
@@ -44,6 +50,7 @@ func find_nearest_player():
 			near = p
 	return near
 
+
 func move():
 	state = "idle"
 	var player = find_nearest_player()
@@ -52,14 +59,18 @@ func move():
 		velocity.x = (2 * int(player.position.x > position.x) - 1)* speed
 	else:
 		velocity.x = 0
-	for p in nearby_players.keys():
-		if nearby_players[p]:
-			p.take_damage(damage)
-			state = "attacking"
+	attack()
 	move_and_slide(velocity, Vector2(0,-1))
 	rpc("remote_move", position, velocity, state)
 	if !is_on_floor():
-		velocity.y += 12
+		velocity.y += GRAVITY
+	
+	
+func attack():
+	for player in enemies_in_range:
+		state = "attacking"
+		player.take_damage(damage)
+	
 	
 remote func take_damage(x):
 	health -= x

--- a/server/entity/Player.gd
+++ b/server/entity/Player.gd
@@ -15,27 +15,26 @@ func _ready():
 	ready = false
 	get_node("hitbox").set_shape(load("res://server/entity/entity_resources/PlayerHitbox.tres"))
 	get_node("area/collision").set_shape(load("res://server/entity/entity_resources/PlayerAreaDetector.tres"))
-	
 	#Spawn at start if beginning of game or if one player present
 	if (w.get_node("entities/players").get_child_count() == 1 || !w.get_node("Spawning/PlayerSpawner").respawn) and !old_pos:
 		position = w.get_node("Spawning/PlayerSpawnPoints").get_child(0).get_global_position()
-	
 	#Respawn on teammates if available
 	elif w.get_node("entities/players").get_child_count() != 1 and w.get_node("Spawning/PlayerSpawner").respawn and !old_pos:
 		var index = randi()%w.get_node("entities/players").get_child_count()
 		position = w.get_node("entities/players").get_child(index).get_global_position()
 	else:
 		old_pos = false
-	
 	set_collision_layer_bit(0, true) # tiles
 	set_collision_mask_bit(0, false) # reset 
 	set_collision_mask_bit(Base.MOB_COLLISION_LAYER, true) # mobs
 	set_collision_mask_bit(Base.PLAYER_COLLISION_LAYER, true) # players
 	set_collision_mask_bit(Base.ITEM_COLLISION_LAYER, true) # players
+	get_node("area").connect("body_entered", self, "_on_area_body_entered")
+	get_node("area").connect("body_exited", self, "_on_area_body_exited")
+	
 	
 var last_direction = 0
 var is_attacking
-
 remote func move(v, is_atk):
 	if v.y < 0:
 		if !(is_on_floor() or test_move(transform, Vector2(0,5))):
@@ -104,6 +103,27 @@ func check_position():
 func give_client_stats():
 	rpc_id(int(get_name()), "update_stats", health, mana, stamina, defense, speed, damage)
 	
+	
+func _on_area_body_entered(body):
+	if body.is_class("TileMap"):
+		pass
+	elif body.who == "mob":
+		var minx = 50
+		var x = position.distance_to(body.position)
+		var A = position.x
+		var B = position.x + -(2*int(last_direction)-1)*50
+		var C = body.position.x
+		if (x < minx and (abs(A-C) + abs(B-C) == abs(A-B))):
+			enemies_in_range[body] = true	
+	
+	
+func _on_area_body_exited(body):
+	if body.is_class("TileMap"):
+		pass
+	elif body.who == "mob":
+		enemies_in_range.erase(body)
+	
+	
 func take_damage(x):
 	health -= float(x)/defense
 	rpc("set_health", health)
@@ -115,8 +135,7 @@ func take_damage(x):
 			position = w.get_node("entities/players").get_child(index).get_global_position()
 		health = MAX_HEALTH/2
 		mana = MAX_MANA/2
-		stamina = MAX_STAMINA/2
-		
+		stamina = MAX_STAMINA/2		
 		rpc("set_health", health)
 		rpc("set_mana", mana)
 		rpc("set_stamina", stamina)
@@ -124,10 +143,7 @@ func take_damage(x):
 
 remote func restore_stats(id):
 	if id == 0:
-		health += 60
-		if (health > MAX_HEALTH):
-			health = MAX_HEALTH
-		
+		health = min(health + 60, MAX_HEALTH)	
 		rpc("set_health", health)
 	elif id == 1:
 		stamina = MAX_STAMINA

--- a/server/entity/class_knight.gd
+++ b/server/entity/class_knight.gd
@@ -1,7 +1,7 @@
 extends "res://server/entity/Player.gd"
 
 const Cooldown = preload('res://server/Cooldown.gd')
-onready var entities = get_node("/root/World/entities/mobs")
+#onready var entities = get_node("/root/World/entities/mobs")
 
 func _ready():
 	classtype = "knight"
@@ -11,20 +11,9 @@ func _process(delta):
 	attack_cooldown.tick(delta)
 onready var attack_cooldown = Cooldown.new(0.5)
 	
-func find_mob_in_attack_range():
-	var minx = 50
-	var near = []
-	for m in entities.get_children():
-		var x = position.distance_to(m.position)
-		var A = position.x
-		var B = position.x + -(2*int(last_direction)-1)*50
-		var C = m.position.x
-		if (x < minx and (abs(A-C) + abs(B-C) == abs(A-B))):
-			near.append(m)
-	return near
+
 func attack():
-	var mobs = find_mob_in_attack_range()
-	if(attack_cooldown.is_ready() and mobs.size() != 0):
-		for m in mobs:
+	if(attack_cooldown.is_ready()):
+		for m in enemies_in_range:
 			m.take_damage(damage)
 			m.position.x += -(2*int(last_direction)-1) * 30

--- a/server/entity/class_rogue.gd
+++ b/server/entity/class_rogue.gd
@@ -1,29 +1,14 @@
 extends "res://server/entity/Player.gd"
 
-onready var world = get_node("/root/World")
-onready var entities = get_node("/root/World/entities/mobs")
+#onready var world = get_node("/root/World")
+#onready var entities = get_node("/root/World/entities/mobs")
 
 
 func _ready():
 	classtype = "rogue"
 	
 	
-func find_mob_in_attack_range():
-	var minx = 50
-	var near = []
-	for m in entities.get_children():
-		var x = position.distance_to(m.position)
-		var A = position.x
-		var B = position.x + -(2*int(last_direction)-1)*50
-		var C = m.position.x
-		if (x < minx and (abs(A-C) + abs(B-C) == abs(A-B))):
-			near.append(m)
-	return near
-	
-	
 func attack():
-	var mobs = find_mob_in_attack_range()
-	if(mobs.size() != 0):
-		for m in mobs:
-			m.take_damage(damage)
-			m.position.x += -(2*int(last_direction)-1) * 15
+	for m in enemies_in_range:
+		m.take_damage(damage)
+		m.position.x += -(2*int(last_direction)-1) * 15

--- a/server/entity/entity.gd
+++ b/server/entity/entity.gd
@@ -2,9 +2,11 @@ extends KinematicBody2D
 
 var who = "none"
 
-var GRAVITY = 12
+const GRAVITY = 12
 
 var velocity = Vector2()
+
+var enemies_in_range = Dictionary()
 
 var state = "idle"
 

--- a/server/spawning/MobSpawner.gd
+++ b/server/spawning/MobSpawner.gd
@@ -17,8 +17,3 @@ func _process(delta):
 		m.set_name(str(id))
 		mobs.add_child(m)
 		get_tree().get_root().get_node("World").spawn_mob(who, id)
-
-
-func _physics_process(delta):
-	for m in mobs.get_children():
-		m.move()


### PR DESCRIPTION
Instead of looping through a list of Mobs in the world (or holding onto a list of all Mobs), Player will now record/log any Mob only when a Mob enters its attack range. Player will then loop through a list of all Mobs within its range and apply damage to them.

Note: This may not bring us any significant performance improvements, but it's a bit more consistent with what was done for Mob in terms of Area2D detection.

I also moved the `_physics_process(delta)` function out of MobSpawner.gd and into Mob itself to give it more control over its own movements.