### PR TITLE
Stamina and Mana update

### DIFF
--- a/server/entity/Player.gd
+++ b/server/entity/Player.gd
@@ -165,6 +165,8 @@ func take_damage(x):
 		rpc("set_health", health)
 		rpc("set_mana", mana)
 		rpc("set_stamina", stamina)
+		
+		rpc_id(self, "reset_clock")
 
 
 remote func restore_stats(id):

--- a/server/entity/Player.gd
+++ b/server/entity/Player.gd
@@ -166,7 +166,7 @@ func take_damage(x):
 		rpc("set_mana", mana)
 		rpc("set_stamina", stamina)
 		
-		rpc_id(self, "reset_clock")
+		rpc_id(int(get_name()), "reset_clock")
 
 
 remote func restore_stats(id):


### PR DESCRIPTION
Mana drains for mage attacks while stamina drains for sprinting and physical attacks. A short pause occurs before regen which can be interrupted by attacking, sprinting, or jumping. While either stat is at 0, sprinting/fireball cannot be used.